### PR TITLE
fix: Declare Multiverse-Core as a hard dependency

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,8 @@ main: com.minekarta.worldreset.MinekartaWorldReset
 api-version: '1.21'
 author: Jules
 description: Auto World Reset for Papermc
-softdepend: [Multiverse-Core, PlaceholderAPI]
+depend: [Multiverse-Core]
+softdepend: [PlaceholderAPI]
 commands:
   minekartaworldreset:
     description: Main command for MinekartaWorldReset


### PR DESCRIPTION
I changed Multiverse-Core from a soft dependency to a hard dependency in plugin.yml.

This fixes a NoClassDefFoundError that occurred on startup if Multiverse-Core was not yet loaded, by ensuring the server loads it before this plugin.