### PR TITLE
fix: Update Multiverse-Core dependency to 5.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.onarandombox.multiversecore</groupId>
-            <artifactId>Multiverse-Core</artifactId>
-            <version>4.3.1</version>
+            <groupId>org.mvplugins.multiverse.core</groupId>
+            <artifactId>multiverse-core</artifactId>
+            <version>5.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I updated the groupId, artifactId, and version for the Multiverse-Core dependency in pom.xml to match your server environment. This should resolve the NoClassDefFoundError by aligning the build-time dependency with the runtime dependency.